### PR TITLE
Changed word "iterate" to "cast" in 04_to_list_to_array.md.

### DIFF
--- a/markdowns/02_Background/04_to_list_to_array.md
+++ b/markdowns/02_Background/04_to_list_to_array.md
@@ -1,7 +1,7 @@
 [//]: # (GENERATED FILE -- DO NOT EDIT)
 # Background Topics - ToList() and ToArray()
 
-Any LINQ method that returns a sequence of elements returns it as an `IEnumerable<T>`. For many applications, it can be difficult to work with this interface, and it may be desirable to **iterate** this enumerable to either a list or an array. Both of these are more intuitive to use.
+Any LINQ method that returns a sequence of elements returns it as an `IEnumerable<T>`. For many applications, it can be difficult to work with this interface, and it may be desirable to **cast** this enumerable to either a list or an array. Both of these are more intuitive to use.
 
 LINQ provides two very handy methods to do just this: [`ToList()`](https://msdn.microsoft.com/en-us/library/bb342261%28v=vs.110%29.aspx) and [`ToArray()`](https://msdn.microsoft.com/en-us/library/bb298736%28v=vs.110%29.aspx). The method names are pretty self-explanatory. They "convert" an `IEnumerable<T>` to either a `List<T>` or an array of type `T[]`.
 


### PR DESCRIPTION
It's called casting, not iterating, from what I read in books and on the internet:
https://stackoverflow.com/questions/961375/casting-ienumerablet-to-listt

You iterate through a loop. Iterate means is to perform or utter repeatedly.

Cast, in the context of C#, is a method by which a value is converted from one data type to another:
https://www.techopedia.com/definition/25168/cast-c-sharp

That's what we have here.